### PR TITLE
Added clang-format and new option to format after document save.

### DIFF
--- a/formatter.lua
+++ b/formatter.lua
@@ -1,7 +1,12 @@
 -- mod-version:1 lite-xl 1.16
 local core = require "core"
+local config = require "core.config"
 local command = require "core.command"
+local Doc = require "core.doc"
 local keymap = require "core.keymap"
+
+-- set to true on your user init.lua to run formatter on each document save
+config.format_on_save = config.format_on_save or false
 
 local formatters = {}
 
@@ -20,7 +25,24 @@ local function get_formatter(filename)
 	return formatter
 end
 
-local function format_current_doc()
+-- sometimes the autoreload plugin doesn't detects the file changed so we
+-- need our own reload_doc function to reload document after formatting it
+local function reload_doc(doc)
+  local fp = io.open(doc.filename, "r")
+  local text = fp:read("*a")
+  fp:close()
+
+  local sel = { doc:get_selection() }
+  doc:remove(1, 1, math.huge, math.huge)
+  doc:insert(1, 1, text:gsub("\r", ""):gsub("\n$", ""))
+  doc:set_selection(table.unpack(sel))
+
+  doc:clean()
+end
+
+-- formats current document and reload it to show changes
+-- to prevent reloading set 'not_reload' to true
+local function format_current_doc(not_reload)
 	local current_doc = core.active_view.doc
 	if current_doc == nil then
 		core.error("no doc is open")
@@ -43,6 +65,26 @@ local function format_current_doc()
 
 	system.exec(cmd) -- all systems go
 
+	if not not_reload then
+		reload_doc(core.active_view.doc)
+	end
+end
+
+local Doc_save = Doc.save
+Doc.save = function(self, ...)
+  Doc_save(self, ...)
+  if config.format_on_save == true and get_formatter(self.filename) then
+    format_current_doc(true)
+    core.add_thread(function()
+    	-- Wait at least 1 second before trying to reload the document
+    	-- to let core Doc.save do its work
+			local current_time = os.time()
+			while current_time == os.time() do
+				coroutine.yield()
+			end
+			reload_doc(core.active_view.doc)
+    end)
+  end
 end
 
 command.add("core.docview", {["formatter:format-doc"] = format_current_doc})

--- a/formatter_clangformat.lua
+++ b/formatter_clangformat.lua
@@ -1,0 +1,16 @@
+-- lite-xl 1.16
+-- for ClangFormat fortmatter
+local config = require "core.config"
+local formatter = require "plugins.formatter"
+
+config.clangformat_args = {"--style=file", "--fallback-style=WebKit", "-i"}
+
+formatter.add_formatter {
+	name = "ClangFormat",
+	file_patterns = {
+		"%.h$", "%.inl$", "%.cpp$", "%.cc$", "%.C$", "%.cxx$",
+    "%.c++$", "%.hh$", "%.H$", "%.hxx$", "%.hpp$", "%.h++$"
+	},
+	command = "clang-format $ARGS $FILENAME",
+	args = config.clangformat_args
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Formatters for [lite](https://github.com/rxi/lite) and [lite-xl](https://github.com/franko/lite-xl)
 
 ## List of formatters (Keep alphabetical)
+- [clang-format](https://clang.llvm.org/docs/ClangFormat.html): `formatter_clangformat.lua`
 - [css-beautify](https://www.npmjs.com/package/js-beautify): `formatter_cssbeautify.lua`
 - [esformatter](https://github.com/millermedeiros/esformatter/): `formatter_esformatter.lua`
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit): `formatter_gdformat.lua`
@@ -16,7 +17,7 @@
 
 3. Make sure you have the command that formatter uses installed, or it won't work.
 
-4. Extra configuration: 
+4. Extra configuration:
     If you want to customize the cli arguments for a specific formatter, you can do this from your `init.lua` script.
     Example:
 ```lua
@@ -27,6 +28,12 @@ config.jsbeautify_args = {"-r", "-s 4", "-p", "-b end-expand"} -- set jsBeautify
 the default keymap to format the current doc is `alt+shift+f`
 the command is `formatter:format-doc`
 
+to format a document at each save add the following config to
+your user `init.lua` as shown:
+```lua
+config.format_on_save = true
+```
+
 ## Adding a formatter
 
 here is an example formatter:
@@ -36,7 +43,7 @@ here is an example formatter:
 -- for JS Beautify fortmatter
 local config = require "core.config"
 local formatter = require "plugins.formatter"
- 
+
 config.jsbeautify_args = {"-r", "-q", "-s 1", "-t", "-p", "-b end-expand"} -- make sure to keep -r arg if you change this
 
 formatter.add_formatter {
@@ -44,7 +51,7 @@ formatter.add_formatter {
     file_patterns = {"%.js$"},
     command = "js-beautify $ARGS $FILENAME",
     args = config.jsbeautify_args
-}   
+}
 ```
 ### a few things to keep in mind
 - make sure to add the lite-xl version tag at the top


### PR DESCRIPTION
Added clang-format for C/C++ language and introduced new option to automatically format a document after save if the the following config is set:

```lua
config.format_on_save = true
```

Also imported the `reload_doc` function from the autoreload plugin to reload the document after a format since sometimes it wasn't been reloaded.