### PR TITLE
Add formatter for zig fmt

### DIFF
--- a/formatter_zigfmt.lua
+++ b/formatter_zigfmt.lua
@@ -1,0 +1,13 @@
+-- lite-xl 1.16
+-- for zig fmt formatter
+local config = require "core.config"
+local formatter = require "plugins.formatter"
+ 
+config.zigfmt_args = {} -- zig fmt doesn't need any args when formatting single file
+
+formatter.add_formatter {
+    name = "zig fmt",
+    file_patterns = {"%.zig$"},
+    command = "zig fmt $ARGS $FILENAME",
+    args = config.zigfmt_args
+}

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 - [html-beautify](https://www.npmjs.com/package/js-beautify): `formatter_htmlbeautify.lua`
 - [js-beautify](https://www.npmjs.com/package/js-beautify): `formatter_jsbeautify.lua`
 - [luaformatter](https://github.com/Koihik/LuaFormatter): `formatter_luaformatter.lua`
+- [zigfmt](https://ziglang.org): `formatter_zigfmt.lua`
 
 ## Installation instructions
 


### PR DESCRIPTION
Zig fmt is the built in formatter of the Zig language compiler.