### PR TITLE
feat: add Prettier formatter

### DIFF
--- a/formatter_prettier.lua
+++ b/formatter_prettier.lua
@@ -1,0 +1,13 @@
+-- mod-version:3 lite-xl 2.1
+-- for Prettier formatter
+local config = require "core.config"
+local formatter = require "plugins.formatter"
+
+config.prettier_args = {"--write"}
+
+formatter.add_formatter {
+	name = "Prettier",
+	file_patterns = { "%.jsx?$", "%.cjs$", "%.mjs$", "%.tsx?$" },
+	command = "npx prettier $ARGS $FILENAME",
+	args = config.prettier_args
+}

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@
 - [html-beautify](https://www.npmjs.com/package/js-beautify): `formatter_htmlbeautify.lua`
 - [js-beautify](https://www.npmjs.com/package/js-beautify): `formatter_jsbeautify.lua`
 - [luaformatter](https://github.com/Koihik/LuaFormatter): `formatter_luaformatter.lua`
+- [prettier](https://prettier.io/): `formatter_prettier.lua`
 - [qmlformat](https://github.com/qt/qtdeclarative): `formatter_qml.lua`
 - [rustfmt](https://github.com/rust-lang/rustfmt): `formatter_rustfmt.lua`
 - [zigfmt](https://ziglang.org): `formatter_zigfmt.lua`


### PR DESCRIPTION
This PR adds support for JS / TS / JSX files with [Prettier](https://prettier.io/).

It uses `npx` to run Prettier, meaning that it would use the version installed in a project or fallback to a global version (`npm install -g prettier`) or install it if not available on the user system.

I've started using Lite-XL today and don't know Lua at all…so don't hesitate to let me know if further improvements are needed.

Thanks!

## Demo

_I'll see at usage if improvements are needed, because it may cause race conditions with other lint extensions but I'm not sure_

https://user-images.githubusercontent.com/75968/209980578-21d3e4c7-633b-41a3-bbb4-3b24d0cb8ba3.mp4
