### PR TITLE
feat: Add Isort and Autoflake for python and add support for .pyi files in black

### DIFF
--- a/formatter_autoflake.lua
+++ b/formatter_autoflake.lua
@@ -1,0 +1,18 @@
+-- mod-version:3 lite-xl 2.1
+-- for autoflake python formatter
+local config = require "core.config"
+local common = require "core.common"
+local formatter = require "plugins.formatter"
+
+config.autoflake_args = common.merge({
+	"--remove-all-unused-imports", "--remove-unused-variables",
+ "--remove-duplicate-keys", "--expand-star-imports", "-ir"
+}, config.autoflake_args)
+
+formatter.add_formatter {
+	name = "Autoflake",
+	file_patterns = {"%.pyi?$"},
+	command = "autoflake $ARGS $FILENAME",
+	args = config.autoflake_args
+}
+

--- a/formatter_black.lua
+++ b/formatter_black.lua
@@ -7,7 +7,7 @@ config.black_args = {}
 
 formatter.add_formatter {
 	name = "Black",
-	file_patterns = {"%.pyi$"},
+	file_patterns = {"%.pyi?$"},
 	command = "black $ARGS $FILENAME",
 	args = config.black_args
 }

--- a/formatter_black.lua
+++ b/formatter_black.lua
@@ -7,7 +7,7 @@ config.black_args = {}
 
 formatter.add_formatter {
 	name = "Black",
-	file_patterns = {"%.py$"},
+	file_patterns = {"%.pyi$"},
 	command = "black $ARGS $FILENAME",
 	args = config.black_args
 }

--- a/formatter_isort.lua
+++ b/formatter_isort.lua
@@ -1,0 +1,13 @@
+-- mod-version:3 lite-xl 2.1
+-- for Isort python formatter
+local config = require "core.config"
+local formatter = require "plugins.formatter"
+
+config.isort_args = {}
+
+formatter.add_formatter {
+	name = "Isort",
+	file_patterns = {"%.pyi?$"},
+	command = "isort $ARGS $FILENAME",
+	args = config.isort_args
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # Formatters for [lite](https://github.com/rxi/lite) and [lite-xl](https://github.com/franko/lite-xl)
 
 ## List of formatters (Keep alphabetical)
+- [autoflake python formatter](https://pypi.org/project/autoflake/): `formatter_autoflake.lua`
 - [black python formatter](https://pypi.org/project/black/): `formatter_black.lua`
 - [clang-format](https://clang.llvm.org/docs/ClangFormat.html): `formatter_clangformat.lua`
 - [cmake-format](https://github.com/cheshirekow/cmake_format): `formatter_cmakeformat.lua`
@@ -11,6 +12,7 @@
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit): `formatter_gdformat.lua`
 - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports): `formatter_golang.lua`
 - [html-beautify](https://www.npmjs.com/package/js-beautify): `formatter_htmlbeautify.lua`
+- [isort python formatter](https://pypi.org/project/isort/): `formatter_isort.lua`
 - [js-beautify](https://www.npmjs.com/package/js-beautify): `formatter_jsbeautify.lua`
 - [luaformatter](https://github.com/Koihik/LuaFormatter): `formatter_luaformatter.lua`
 - [qmlformat](https://github.com/qt/qtdeclarative): `formatter_qml.lua`


### PR DESCRIPTION
This PR adds support for code formatters isort and autoflake and changes file_patterns on black to support .py and .pyi files.