### PR TITLE
Add csharpier support.

### DIFF
--- a/formatter_csharpier.lua
+++ b/formatter_csharpier.lua
@@ -1,5 +1,5 @@
 -- mod-version:3 lite-xl 2.1
--- for C# csharpier
+-- for C# csharpier formatter
 local config = require "core.config"
 local formatter = require "plugins.formatter"
 

--- a/formatter_csharpier.lua
+++ b/formatter_csharpier.lua
@@ -8,6 +8,6 @@ config.csharpier_args = {} -- csharpier doesn't need any args when formatting si
 formatter.add_formatter {
     name = "csharpier",
     file_patterns = {"%.cs$"},
-    command = "dotnet csharpier $ARGS $FILENAME",
+    command = "dotnet-csharpier $ARGS $FILENAME",
     args = config.csharpier_args
 }

--- a/formatter_csharpier.lua
+++ b/formatter_csharpier.lua
@@ -1,0 +1,13 @@
+-- mod-version:3 lite-xl 2.1
+-- for C# csharpier
+local config = require "core.config"
+local formatter = require "plugins.formatter"
+
+config.csharpier_args = {} -- csharpier doesn't need any args when formatting single file
+
+formatter.add_formatter {
+    name = "csharpier",
+    file_patterns = {"%.cs$"},
+    command = "dotnet csharpier $ARGS $FILENAME",
+    args = config.csharpier_args
+}

--- a/formatter_rustfmt.lua
+++ b/formatter_rustfmt.lua
@@ -1,5 +1,5 @@
 -- mod-version:3 lite-xl 2.1
--- for Rust fortmatter
+-- for Rust formatter
 local config = require "core.config"
 local formatter = require "plugins.formatter"
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 - [black python formatter](https://pypi.org/project/black/): `formatter_black.lua`
 - [clang-format](https://clang.llvm.org/docs/ClangFormat.html): `formatter_clangformat.lua`
 - [cmake-format](https://github.com/cheshirekow/cmake_format): `formatter_cmakeformat.lua`
+- [csharpier](https://github.com/belav/csharpier): `formatter_csharpier.lua`
 - [css-beautify](https://www.npmjs.com/package/js-beautify): `formatter_cssbeautify.lua`
 - [dartformat](https://dart.dev/tools/dart-format): `formatter_dartformat.lua`
 - [dfmt](https://github.com/dlang-community/dfmt): `formatter_dfmt.lua`


### PR DESCRIPTION
This PR adds support for the `csharpier` C# formatter.

You can test this PR with:
- `git clone https://github.com/PerilousBooklet/lite-xl-formatters.git`
- `git fetch && git checkout PR_csharp`
- `lpm run --ephemeral ./ formatter formatter_csharpier`