### PR TITLE
Add `prettier` support.

### DIFF
--- a/formatter_prettier.lua
+++ b/formatter_prettier.lua
@@ -4,11 +4,13 @@
 local formatter = require "plugins.formatter"
 local config = require "core.config"
 
+config.prettier_args = {"--write"}
+
 formatter.add_formatter {
     name = "Prettier",
-    file_patterns = {"%.less&", "%.scss&", "%.json&", "%.jsx?$", "%.ts$"},
-    command = "prettier $ARGS $FILENAME",
-    args = { "-w" }
+    file_patterns = {"%.less$", "%.scss$", "%.json$", "%.jsx?$", "%.ts$"},
+    command = "npx prettier $ARGS $FILENAME",
+    args = config.prettier_args
 }
 
 config.format_on_save = true

--- a/formatter_prettier.lua
+++ b/formatter_prettier.lua
@@ -1,0 +1,14 @@
+-- mod-version:3 lite-xl 2.1
+
+-- For the prettier formatter
+local formatter = require "plugins.formatter"
+local config = require "core.config"
+
+formatter.add_formatter {
+    name = "Prettier",
+    file_patterns = {"%.less&", "%.scss&", "%.json&", "%.jsx?$", "%.ts$"},
+    command = "prettier $ARGS $FILENAME",
+    args = { "-w" }
+}
+
+config.format_on_save = true

--- a/manifest.json
+++ b/manifest.json
@@ -225,6 +225,15 @@
       "dependencies": { "formatter": ">=0.1" }
     },
     {
+      "id": "formatter_prettier",
+      "mod_version": "3",
+      "name": "formatter_prettier",
+      "path": "/formatter_prettier.lua",
+      "type": "plugin",
+      "version": "0.1",
+      "dependencies": { "formatter": ">=0.1" }
+    },
+    {
       "id": "formatter_qmlformat",
       "mod_version": "3",
       "name": "formatter_qmlformat",

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
 - [luaformatter](https://github.com/Koihik/LuaFormatter): `formatter_luaformatter.lua`
 - [ormolu](https://github.com/tweag/ormolu): `formatter_ormolu.lua`
 - [perltidy](https://github.com/perltidy/perltidy): `formatter_perltidy.lua`
+- [prettier](https://github.com/prettier/prettier): `formatter_prettier.lua`
 - [ocp-indent](https://github.com/OCamlPro/ocp-indent): `formatter_ocpindent.lua`
 - [qmlformat](https://github.com/qt/qtdeclarative): `formatter_qml.lua`
 - [rubocop](https://github.com/rubocop/rubocop): `formatter_rubocop.lua`


### PR DESCRIPTION
This PR adds `prettier` support for `.less`, `.scss`, `.json`, `.js`, `.jsx` and `.ts` files.

You can test this PR with:
- `git clone https://github.com/PerilousBooklet/lite-xl-formatters.git`
- `git fetch && git checkout PR_prettier`
- `lpm run --ephemeral ./ formatter formatter_prettier`