### PR TITLE
Fix dependency version for `cljfmt`.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
       "path": "/formatter_cljfmt.lua",
       "type": "plugin",
       "version": "0.1",
-      "dependencies": { "formatter": ">=0.1" }
+      "dependencies": { "formatter": ">=0.2" }
     },
     {
       "id": "formatter_cmakeformat",


### PR DESCRIPTION
The Clojure formatter `cljfmt` requires `formatter` version equal or greater than `0.2` because that's when the multiple command execution feature was introduced and `cljfmt` uses two commands to format a file.

You can test this PR with:
- `git clone https://github.com/PerilousBooklet/lite-xl-formatters.git`
- `git fetch && git checkout PR_cljfmt`
- `lpm run --ephemeral ./ formatter formatter_cljfmt`